### PR TITLE
1.0.0 update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# v1.0.0
+
+- Add `until` opening mode and associated settings
+- Add JSON export / import of settings
+    - Importing settings with a loot table checksum mismatch will cause a warning but won't block the import
+    - Incompatible settings will simply be ignored. Re-exporting loaded settings will update them to "fit" the current
+      loot table
+- Add support for "logical" recursive boxes (auto-opening them immediately when dropped, and adding their content to the
+  original box's result)
+- Add loot table for WoT PC's Holiday Ops 2024 event
+- Add loot table for WoT PC's Paint It GREEN! event
+- Loot table format is now considered stable. If it needs to be modified, the modification should be new optional fields
+  only, and breaking changes should be handled with backwards compatibility.
+
 # v0.4.0
 
 - Rework stats panel

--- a/README.md
+++ b/README.md
@@ -3,40 +3,22 @@
 Pandora is a lootbox-opening simulator.
 
 It supports custom loot tables, allowing you to enjoy free gambling for any game you want (as long as you are willing to
-write some JSON first if that game is not World Of Tanks).
+write some JSON first).
 
 It offers 3 opening "modes":
 
-- "unlimited": open the boxes you want one at a time and see what you get
-- "budget": pick a set amount of starting boxes, and open them until you run out (or let the simulator quickly open
+- "Unlimited": open the boxes you want one at a time and see what you get
+- "Budget": pick a set amount of starting boxes, and open them until you run out (or let the simulator quickly open
   everything to see the results)
-- "until": set your goal prize(s) and let the simulator purchase boxes one by one until your goal is reached. You can
-  run thousands of iterations of this simulation to generate "best case", "average" and "worst case" **estimates**
-  (never take these numbers as definite requirements, it's still just statistics, your mileage WILL vary).
+- "Until...": set your goal prize(s) and let the simulator purchase boxes one by one until your goal is reached. You can
+  run multiple iterations of this simulation in parallel to generate "best case", "average" and "worst case"
+  **estimates** (never take these numbers as definite requirements, it's still just statistics, your mileage WILL vary).
 
 The UI lets you easily setup your session, eliminate rewards you already own from the loot pool, see your opening
 history and visualize your rewards and other statistics.
 
 Pandora supports common lootbox mechanics like pity, duplicate prevention/compensation, and of course, "tiered" (aka
 "recursive" or "matryoshka") lootboxes ! Why is that a thing ? Go ask Wargaming !
-
-Current status of planned features:
-
-- Loot table loading: **OK**
-- "Unlimited" mode: **OK**
-- "Budget" mode: **OK**
-- "Until" mode: **not implemented yet**
-- Settings: mode selector and pre-owned rewards **OK**, import/export **not implemented yet**
-- Session stats and opening history: **OK**
-
-Roadmap:
-
-- "Until" mode in single-iteration (v0.5.0)
-- "Until" mode in multi-iterations (v1.0.0)
-- Settings import/export as JSON (v1.0.0)
-- Dedicated stats for "Until" mode in multi-iterations (v1.0.0)
-- Improve mobile experience (after v1.0.0)
-- Handle "logical" (instant-open) recursive lootboxes (after v1.0.0, I will need more non-WoT loot tables to test it)
 
 ## Context
 
@@ -61,25 +43,41 @@ You can try the simulator online at https://daspood.github.io/.
 You can also run the code locally by cloning the repository and checking the scripts in the [package.json](package.json)
 file.
 
-Note that, in both cases, everything runs on your browser, there is no server, so keep that in mind before launching
+Note that, in both cases, everything runs in your browser, there is no server, so keep that in mind before launching
 tens of thousands of simulations in parallel. Your CPU will scream, not mine.
 
 ## How to use
 
-I hope the UI is clear enough for now. I will add a more detailed explanation once it is closer to completion.
+Once a loot table is loaded:
+
+- Top-left button opens a "stats" panel giving you info about your session (rewards obtained, lootboxes opened, opening
+  history...).
+- Top-right button redirects you to this GitHub repository where you can view the source code and open issues.
+- Bottom-left button, only available in "budget" mode, allows you to "purchase" the lootboxes you will then open.
+- Bottom-middle button allows you to open one box. In "budget" mode, you can also let the simulator open boxes
+  automatically one by one, or all at once.
+- Bottom-right button opens a "settings" menu where you can select the opening mode, rewards you already own (to treat
+  them as duplicates from the start), what the stopping point is for "until" mode, export/import settings as JSON, and
+  reset the session stats.
+- Above the "open" button, you can select the lootbox you wish to open (useful for tiered-lootboxes scenarios)
+- In the center of the screen, you will see the content of the last lootbox that was opened.
 
 ## Technical details
 
 ### Loot table
 
-The algorithm will use a specified loot table to handle everything in a rolling session. The loot table format is very
-specific, and well documented in [this file](src/types/lootTable.d.ts), you can find provided samples in
-[this directory](src/assets/lootTables). Everything the algorithm does, including how it handles its configuration,
-depends on the loaded loot table.
+The algorithm will use a specified loot table to handle everything in a rolling session. Everything the algorithm does,
+including how it handles its configuration, depends on the loaded loot table.
+
+The loot table format is very specific, and well documented in [this file](src/types/lootTable.d.ts), you can find
+provided samples in [this directory](src/assets/lootTables). The format should now be stable, any future change will
+hopefully be optional and not break existing loot tables. If breaking changes eventually happen, I will try to have
+backwards compatibility one way or another.
 
 The loaded loot table will be fully validated and type checked to make sure it will work with the simulator. The
 validator, available [here](src/scripts/lootTableValidator.ts), only checks that the expected (documented) fields are
-valid, but ignores undocumented fields, so check for typos yourself.
+valid, but ignores undocumented fields, so check for typos yourself. Everything else in the app assumes the loaded loot
+table is valid, things **will** break if it's not.
 
 If you want to write your own loot table for a game with somewhat complicated lootbox mechanics, take the time to really
 think about what these mechanics imply and how you can "translate" them into more common mechanics. For example:
@@ -100,14 +98,6 @@ think about what these mechanics imply and how you can "translate" them into mor
 
 Overall, try to keep it simple. Some mechanics are overly complicated, but can either be dumbed down to a more simple
 mechanic, or ignored because the details aren't that important.
-
-***WARNING: THE LOOT TABLE FORMAT IS NOT YET FINALIZED AND MAY STILL CHANGE UNEXPECTEDLY AS I FIGURE OUT HOW TO PROPERLY
-HANDLE EVERYTHING. THIS WARNING WILL BE REMOVED ONCE IT'S STABLE.***
-
-### Config
-
-The simulator will let you save and load configs to not have to manually pick every parameter every time. This section
-will be expanded when that feature is ready.
 
 ### Opening algorithm
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,18 @@
 {
     "name": "pandora",
-    "version": "0.0.0",
+    "version": "0.4.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "pandora",
-            "version": "0.0.0",
+            "version": "0.4.0",
             "dependencies": {
+                "apexcharts": "^5.3.4",
                 "bootstrap": "^5.3.7",
                 "bootstrap-icons": "^1.13.1",
                 "react": "^19.1.1",
+                "react-apexcharts": "^1.7.0",
                 "react-bootstrap": "^2.10.10",
                 "react-dom": "^19.1.1",
                 "react-icons": "^5.5.0"
@@ -2135,6 +2137,57 @@
                 "@sinonjs/commons": "^3.0.1"
             }
         },
+        "node_modules/@svgdotjs/svg.draggable.js": {
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/@svgdotjs/svg.draggable.js/-/svg.draggable.js-3.0.6.tgz",
+            "integrity": "sha512-7iJFm9lL3C40HQcqzEfezK2l+dW2CpoVY3b77KQGqc8GXWa6LhhmX5Ckv7alQfUXBuZbjpICZ+Dvq1czlGx7gA==",
+            "peerDependencies": {
+                "@svgdotjs/svg.js": "^3.2.4"
+            }
+        },
+        "node_modules/@svgdotjs/svg.filter.js": {
+            "version": "3.0.9",
+            "resolved": "https://registry.npmjs.org/@svgdotjs/svg.filter.js/-/svg.filter.js-3.0.9.tgz",
+            "integrity": "sha512-/69XMRCDoam2HgC4ldHIaDgeQf1ViHIsa0Ld4uWgiXtZ+E24DWHe/9Ib6kbNiZ7WRIdlVokUDR1Fg0kjIpkfbw==",
+            "dependencies": {
+                "@svgdotjs/svg.js": "^3.2.4"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/@svgdotjs/svg.js": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/@svgdotjs/svg.js/-/svg.js-3.2.4.tgz",
+            "integrity": "sha512-BjJ/7vWNowlX3Z8O4ywT58DqbNRyYlkk6Yz/D13aB7hGmfQTvGX4Tkgtm/ApYlu9M7lCQi15xUEidqMUmdMYwg==",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Fuzzyma"
+            }
+        },
+        "node_modules/@svgdotjs/svg.resize.js": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@svgdotjs/svg.resize.js/-/svg.resize.js-2.0.5.tgz",
+            "integrity": "sha512-4heRW4B1QrJeENfi7326lUPYBCevj78FJs8kfeDxn5st0IYPIRXoTtOSYvTzFWgaWWXd3YCDE6ao4fmv91RthA==",
+            "engines": {
+                "node": ">= 14.18"
+            },
+            "peerDependencies": {
+                "@svgdotjs/svg.js": "^3.2.4",
+                "@svgdotjs/svg.select.js": "^4.0.1"
+            }
+        },
+        "node_modules/@svgdotjs/svg.select.js": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/@svgdotjs/svg.select.js/-/svg.select.js-4.0.3.tgz",
+            "integrity": "sha512-qkMgso1sd2hXKd1FZ1weO7ANq12sNmQJeGDjs46QwDVsxSRcHmvWKL2NDF7Yimpwf3sl5esOLkPqtV2bQ3v/Jg==",
+            "engines": {
+                "node": ">= 14.18"
+            },
+            "peerDependencies": {
+                "@svgdotjs/svg.js": "^3.2.4"
+            }
+        },
         "node_modules/@swc/helpers": {
             "version": "0.5.17",
             "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
@@ -2862,6 +2915,11 @@
                 "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
             }
         },
+        "node_modules/@yr/monotone-cubic-spline": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@yr/monotone-cubic-spline/-/monotone-cubic-spline-1.0.3.tgz",
+            "integrity": "sha512-FQXkOta0XBSUPHndIKON2Y9JeQz5ZeMqLYZVVK93FliNBFm7LNMIZmY6FrMEB9XPcDbE2bekMbZD6kzDkxwYjA=="
+        },
         "node_modules/acorn": {
             "version": "8.15.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -2964,6 +3022,19 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/apexcharts": {
+            "version": "5.3.4",
+            "resolved": "https://registry.npmjs.org/apexcharts/-/apexcharts-5.3.4.tgz",
+            "integrity": "sha512-N0gNh8uLu/BN8N+BCphNK+gZAoSoUtDDn1jFGB+3+EMcv8s6vajuP3W0g4dMLTRp6chFkjMmQK3uD8pz4ISmLA==",
+            "dependencies": {
+                "@svgdotjs/svg.draggable.js": "^3.0.4",
+                "@svgdotjs/svg.filter.js": "^3.0.8",
+                "@svgdotjs/svg.js": "^3.2.4",
+                "@svgdotjs/svg.resize.js": "^2.0.2",
+                "@svgdotjs/svg.select.js": "^4.0.1",
+                "@yr/monotone-cubic-spline": "^1.0.3"
             }
         },
         "node_modules/arg": {
@@ -5751,6 +5822,18 @@
             "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/react-apexcharts": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/react-apexcharts/-/react-apexcharts-1.7.0.tgz",
+            "integrity": "sha512-03oScKJyNLRf0Oe+ihJxFZliBQM9vW3UWwomVn4YVRTN1jsIR58dLWt0v1sb8RwJVHDMbeHiKQueM0KGpn7nOA==",
+            "dependencies": {
+                "prop-types": "^15.8.1"
+            },
+            "peerDependencies": {
+                "apexcharts": ">=4.0.0",
+                "react": ">=0.13"
             }
         },
         "node_modules/react-bootstrap": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "pandora",
-    "version": "0.4.0",
+    "version": "1.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "pandora",
-            "version": "0.4.0",
+            "version": "1.0.0",
             "dependencies": {
                 "apexcharts": "^5.3.4",
                 "bootstrap": "^5.3.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "pandora",
     "private": true,
-    "version": "0.4.0",
+    "version": "1.0.0",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -11,9 +11,11 @@
         "test": "jest --testPathPatterns=src/tests --runInBand --verbose=false"
     },
     "dependencies": {
+        "apexcharts": "^5.3.4",
         "bootstrap": "^5.3.7",
         "bootstrap-icons": "^1.13.1",
         "react": "^19.1.1",
+        "react-apexcharts": "^1.7.0",
         "react-bootstrap": "^2.10.10",
         "react-dom": "^19.1.1",
         "react-icons": "^5.5.0"

--- a/src/App.css
+++ b/src/App.css
@@ -19,9 +19,6 @@ p {
     margin: 0 !important;
 }
 
-button {
-}
-
 .icon-button {
     display: inline-flex !important;
     align-items: center !important;

--- a/src/App.css
+++ b/src/App.css
@@ -18,3 +18,13 @@ body, html {
 p {
     margin: 0 !important;
 }
+
+button {
+}
+
+.icon-button {
+    display: inline-flex !important;
+    align-items: center !important;
+    line-height: 22px !important;
+    padding: 12px !important;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -274,7 +274,7 @@ export default function App() {
                     <Container fluid className="d-flex align-items-center">
                         <InfoHeader session={session} onOpenStatsPanel={onOpenStatsPanel} />
                     </Container>
-                    <Container fluid className="d-flex align-items-center flex-grow-1">
+                    <Container fluid className="d-flex align-items-center flex-grow-1 overflow-y-auto">
                         <ResultDisplay session={session} />
                     </Container>
                     <Container fluid className="d-flex align-items-center">

--- a/src/assets/lootTables/world_of_tanks_pc-2024_12-holiday_ops_2025.json
+++ b/src/assets/lootTables/world_of_tanks_pc-2024_12-holiday_ops_2025.json
@@ -1,0 +1,327 @@
+{
+    "game": "World Of Tanks PC",
+    "eventName": "Holiday Ops 2025",
+    "startDate": "2024-12-06",
+    "endDate": "2025-01-13",
+    "recursive": false,
+    "autoOpenRecursive": false,
+    "author": "DaSpood",
+    "source": "'https://worldoftanks.eu/en/news/specials/holiday-ops-large-boxes-december-2024/' for loot slots, 'https://www.13disciple.stream/24-25-loot-box-guide.html' for drop rates in main slot",
+    "notes": "Cosmetics and Holiday Ops stuff not differentiated because no real compensation value. 3D styles too complicated to handle and they're a separate slot anyway so no big deal.",
+    "lootboxes": [
+        {
+            "name": "Large Box",
+            "pictureUrl": "https://content-wg.gcdn.co/locdoc/ops-boxes-2025/img/bundle.0b6310.png",
+            "purchasable": true,
+            "mainPrizeHardPity": 50,
+            "mainPrizeDuplicates": "remove",
+            "secondaryPrizeDuplicates": "remove",
+            "lootSlots": [
+                {
+                    "alias": "Guaranteed slot 1 (Resources)",
+                    "dropRate": 1,
+                    "contentType": "filler",
+                    "lootGroups": [
+                        {
+                            "alias": "Resources",
+                            "dropRate": 1,
+                            "lootDrops": [
+                                {
+                                    "name": "resources",
+                                    "pictureUrl": "https://content-wg.gcdn.co/locdoc/ops-boxes-2025/img/random_resource.b2b880.png",
+                                    "dropRate": 1,
+                                    "amount": 200
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "alias": "Guaranteed slot 2 (Gold)",
+                    "dropRate": 1,
+                    "contentType": "filler",
+                    "lootGroups": [
+                        {
+                            "alias": "Gold",
+                            "dropRate": 1,
+                            "lootDrops": [
+                                {
+                                    "name": "gold",
+                                    "pictureUrl": "https://discoff.net/image/cache/catalog/2500_gold-600x600.png",
+                                    "dropRate": 1,
+                                    "amount": 250
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "alias": "Guaranteed slot 3 (Main reward)",
+                    "dropRate": 1,
+                    "lootGroups": [
+                        {
+                            "alias": "Premium account",
+                            "dropRate": 0.364,
+                            "contentType": "filler",
+                            "lootDrops": [
+                                {
+                                    "name": "days of premium account",
+                                    "pictureUrl": "https://na-wotp.wgcdn.co/dcont/fb/image/440_wot_premium.png",
+                                    "dropRate": 0.80,
+                                    "amount": 1
+                                },
+                                {
+                                    "name": "days of premium account",
+                                    "pictureUrl": "https://na-wotp.wgcdn.co/dcont/fb/image/440_wot_premium.png",
+                                    "dropRate": 0.15,
+                                    "amount": 3
+                                },
+                                {
+                                    "name": "days of premium account",
+                                    "pictureUrl": "https://na-wotp.wgcdn.co/dcont/fb/image/440_wot_premium.png",
+                                    "dropRate": 0.05,
+                                    "amount": 7
+                                }
+                            ]
+                        },
+                        {
+                            "alias": "Gold",
+                            "dropRate": 0.21,
+                            "contentType": "filler",
+                            "lootDrops": [
+                                {
+                                    "name": "gold",
+                                    "pictureUrl": "https://discoff.net/image/cache/catalog/2500_gold-600x600.png",
+                                    "dropRate": 0.80,
+                                    "amount": 250
+                                },
+                                {
+                                    "name": "gold",
+                                    "pictureUrl": "https://discoff.net/image/cache/catalog/2500_gold-600x600.png",
+                                    "dropRate": 0.15,
+                                    "amount": 500
+                                },
+                                {
+                                    "name": "gold",
+                                    "pictureUrl": "https://discoff.net/image/cache/catalog/2500_gold-600x600.png",
+                                    "dropRate": 0.05,
+                                    "amount": 1000
+                                }
+                            ]
+                        },
+                        {
+                            "alias": "Credits",
+                            "dropRate": 0.2854,
+                            "contentType": "filler",
+                            "lootDrops": [
+                                {
+                                    "name": "credits",
+                                    "pictureUrl": "https://eu-wotp.wgcdn.co/dcont/fb/image/new_credits_icon_440x440_png.png",
+                                    "dropRate": 0.80,
+                                    "amount": 100000
+                                },
+                                {
+                                    "name": "credits",
+                                    "pictureUrl": "https://eu-wotp.wgcdn.co/dcont/fb/image/new_credits_icon_440x440_png.png",
+                                    "dropRate": 0.20,
+                                    "amount": 500000
+                                }
+                            ]
+                        },
+                        {
+                            "alias": "Low-tier tanks",
+                            "dropRate": 0.1166,
+                            "contentType": "secondary",
+                            "lootDrops": [
+                                {
+                                    "name": "SU-100I",
+                                    "displayPriority": 5,
+                                    "pictureUrl": "https://assets.tanks.gg/icons/tanks/standard/ussr-R225_SU_100i.png",
+                                    "dropRate": 0.10,
+                                    "amount": 1,
+                                    "substitute": {
+                                        "name": "gold",
+                                        "pictureUrl": "https://discoff.net/image/cache/catalog/2500_gold-600x600.png",
+                                        "amount": 1500
+                                    }
+                                },
+                                {
+                                    "name": "Pz.Kpfw. 38 (K)",
+                                    "displayPriority": 5,
+                                    "pictureUrl": "https://assets.tanks.gg/icons/tanks/standard/germany-G124_Pz_Kpfw_38_K.png",
+                                    "dropRate": 0.10,
+                                    "amount": 1,
+                                    "substitute": {
+                                        "name": "gold",
+                                        "pictureUrl": "https://discoff.net/image/cache/catalog/2500_gold-600x600.png",
+                                        "amount": 1300
+                                    }
+                                },
+                                {
+                                    "name": "Type 1 Ho-Ni II",
+                                    "displayPriority": 4,
+                                    "pictureUrl": "https://assets.tanks.gg/icons/tanks/standard/japan-J50_Type_1_Ho_Ni_II.png",
+                                    "dropRate": 0.20,
+                                    "amount": 1,
+                                    "substitute": {
+                                        "name": "gold",
+                                        "pictureUrl": "https://discoff.net/image/cache/catalog/2500_gold-600x600.png",
+                                        "amount": 950
+                                    }
+                                },
+                                {
+                                    "name": "M3A3 Stuart",
+                                    "displayPriority": 3,
+                                    "pictureUrl": "https://assets.tanks.gg/icons/tanks/standard/usa-A76_M3_A3.png",
+                                    "dropRate": 0.30,
+                                    "amount": 1,
+                                    "substitute": {
+                                        "name": "gold",
+                                        "pictureUrl": "https://discoff.net/image/cache/catalog/2500_gold-600x600.png",
+                                        "amount": 500
+                                    }
+                                },
+                                {
+                                    "name": "AMR P.103",
+                                    "displayPriority": 2,
+                                    "pictureUrl": "https://assets.tanks.gg/icons/tanks/standard/france-F39_AMR_P103.png",
+                                    "dropRate": 0.30,
+                                    "amount": 1,
+                                    "substitute": {
+                                        "name": "gold",
+                                        "pictureUrl": "https://discoff.net/image/cache/catalog/2500_gold-600x600.png",
+                                        "amount": 500
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "alias": "High-tier tanks",
+                            "dropRate": 0.024,
+                            "contentType": "main",
+                            "lootDrops": [
+                                {
+                                    "name": "DZT-159",
+                                    "displayPriority": 9,
+                                    "pictureUrl": "https://assets.tanks.gg/icons/tanks/standard/china-Ch61_DZT_159.png",
+                                    "dropRate": 0.15,
+                                    "amount": 1,
+                                    "substitute": {
+                                        "name": "gold",
+                                        "pictureUrl": "https://discoff.net/image/cache/catalog/2500_gold-600x600.png",
+                                        "amount": 11900
+                                    }
+                                },
+                                {
+                                    "name": "Toro",
+                                    "displayPriority": 9,
+                                    "pictureUrl": "https://assets.tanks.gg/icons/tanks/standard/italy-It34_Toro.png",
+                                    "dropRate": 0.15,
+                                    "amount": 1,
+                                    "substitute": {
+                                        "name": "gold",
+                                        "pictureUrl": "https://discoff.net/image/cache/catalog/2500_gold-600x600.png",
+                                        "amount": 12450
+                                    }
+                                },
+                                {
+                                    "name": "FV226 Contradictious",
+                                    "displayPriority": 8,
+                                    "pictureUrl": "https://assets.tanks.gg/icons/tanks/standard/uk-GB139_FV226_Contradictious.png",
+                                    "dropRate": 0.23,
+                                    "amount": 1,
+                                    "substitute": {
+                                        "name": "gold",
+                                        "pictureUrl": "https://discoff.net/image/cache/catalog/2500_gold-600x600.png",
+                                        "amount": 10200
+                                    }
+                                },
+                                {
+                                    "name": "XM57",
+                                    "displayPriority": 8,
+                                    "pictureUrl": "https://assets.tanks.gg/icons/tanks/standard/usa-A168_XM_57.png",
+                                    "dropRate": 0.24,
+                                    "amount": 1,
+                                    "substitute": {
+                                        "name": "gold",
+                                        "pictureUrl": "https://discoff.net/image/cache/catalog/2500_gold-600x600.png",
+                                        "amount": 9400
+                                    }
+                                },
+                                {
+                                    "name": "Vz. 68 Squall",
+                                    "displayPriority": 8,
+                                    "pictureUrl": "https://assets.tanks.gg/icons/tanks/standard/czech-Cz33_Vz_68_Squall.png",
+                                    "dropRate": 0.23,
+                                    "amount": 1,
+                                    "substitute": {
+                                        "name": "gold",
+                                        "pictureUrl": "https://discoff.net/image/cache/catalog/2500_gold-600x600.png",
+                                        "amount": 6500
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "alias": "Filler slot 1 (Decorations)",
+                    "dropRate": 0.25,
+                    "contentType": "filler",
+                    "lootGroups": [
+                        {
+                            "alias": "Decorations",
+                            "dropRate": 1,
+                            "lootDrops": [
+                                {
+                                    "name": "decoration",
+                                    "pictureUrl": "https://content-wg.gcdn.co/locdoc/ops-boxes-2025/img/random_decoration.71b6ef.png",
+                                    "dropRate": 1,
+                                    "amount": 1
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "alias": "Filler slot 2 (3D attachments)",
+                    "dropRate": 0.06,
+                    "contentType": "filler",
+                    "lootGroups": [
+                        {
+                            "alias": "3D attachments",
+                            "dropRate": 1,
+                            "lootDrops": [
+                                {
+                                    "name": "3D attachment",
+                                    "pictureUrl": "https://clan.akamai.steamstatic.com/images//39263509/fc34c8de5cfc7f4a2b4ef270dce8ad8f8a2011e2.png",
+                                    "dropRate": 1,
+                                    "amount": 1
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "alias": "Filler slot 3 (3D styles)",
+                    "dropRate": 0.05,
+                    "contentType": "filler",
+                    "lootGroups": [
+                        {
+                            "alias": "3D styles",
+                            "dropRate": 1,
+                            "lootDrops": [
+                                {
+                                    "name": "3D style",
+                                    "pictureUrl": "https://wiki.wgcdn.co/images/thumb/c/c9/WoT-PC-3D-Styles-Icon.png/120px-WoT-PC-3D-Styles-Icon.png",
+                                    "dropRate": 1,
+                                    "amount": 1
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/assets/lootTables/world_of_tanks_pc-2025_03-paint_it_green.json
+++ b/src/assets/lootTables/world_of_tanks_pc-2025_03-paint_it_green.json
@@ -1,0 +1,298 @@
+{
+    "game": "World Of Tanks PC",
+    "eventName": "Paint It GREEN!",
+    "startDate": "2025-03-13",
+    "endDate": "2025-03-19",
+    "recursive": false,
+    "autoOpenRecursive": false,
+    "author": "DaSpood",
+    "source": "'https://worldoftanks.asia/ko/news/specials/emerald-chests-2025/', hidden below the list of drops",
+    "notes": "3D attachments bundled into 1 drop type because nobody cares about them.",
+    "lootboxes": [
+        {
+            "name": "Emerald Chest",
+            "pictureUrl": "https://eu-wotp.wgcdn.co/dcont/fb/image/lootboxes_system_base_boxes_arts_600x450.png",
+            "purchasable": true,
+            "mainPrizeHardPity": 50,
+            "mainPrizeDuplicates": "remove",
+            "secondaryPrizeDuplicates": "allowed",
+            "lootSlots": [
+                {
+                    "alias": "Guaranteed slot 1 (Premium account, Personal xp reserves)",
+                    "dropRate": 1,
+                    "contentType": "filler",
+                    "lootGroups": [
+                        {
+                            "alias": "Premium account, Personal xp reserves",
+                            "dropRate": 1,
+                            "lootDrops": [
+                                {
+                                    "name": "days of premium account",
+                                    "pictureUrl": "https://na-wotp.wgcdn.co/dcont/fb/image/440_wot_premium.png",
+                                    "dropRate": 0.33,
+                                    "amount": 1
+                                },
+                                {
+                                    "name": "days of premium account",
+                                    "pictureUrl": "https://na-wotp.wgcdn.co/dcont/fb/image/440_wot_premium.png",
+                                    "dropRate": 0.01,
+                                    "amount": 3
+                                },
+                                {
+                                    "name": "personal reserve: +100% combat xp",
+                                    "pictureUrl": "https://content-wg.gcdn.co/locdoc/rich-article/15th-anniversary-hub/img/bp_pr_credits.6e9500.png",
+                                    "dropRate": 0.32,
+                                    "amount": 1
+                                },
+                                {
+                                    "name": "personal reserve: +100% combat xp",
+                                    "pictureUrl": "https://content-wg.gcdn.co/locdoc/rich-article/15th-anniversary-hub/img/bp_pr_credits.6e9500.png",
+                                    "dropRate": 0.01,
+                                    "amount": 3
+                                },
+                                {
+                                    "name": "personal reserve: +300% free & crew xp",
+                                    "pictureUrl": "https://tanki-media-content.tanki.su/tanki-media/images/stronghold/awards/7.png",
+                                    "dropRate": 0.32,
+                                    "amount": 1
+                                },
+                                {
+                                    "name": "personal reserve: +300% free & crew xp",
+                                    "pictureUrl": "https://tanki-media-content.tanki.su/tanki-media/images/stronghold/awards/7.png",
+                                    "dropRate": 0.01,
+                                    "amount": 3
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "alias": "Guaranteed slot 2 (Credits, Personal credit reserves, Crew books)",
+                    "dropRate": 1,
+                    "contentType": "filler",
+                    "lootGroups": [
+                        {
+                            "alias": "Credits, Personal credit reserves, Crew books",
+                            "dropRate": 1,
+                            "lootDrops": [
+                                {
+                                    "name": "credits",
+                                    "pictureUrl": "https://eu-wotp.wgcdn.co/dcont/fb/image/new_credits_icon_440x440_png.png",
+                                    "dropRate": 0.45,
+                                    "amount": 50000
+                                },
+                                {
+                                    "name": "credits",
+                                    "pictureUrl": "https://eu-wotp.wgcdn.co/dcont/fb/image/new_credits_icon_440x440_png.png",
+                                    "dropRate": 0.05,
+                                    "amount": 100000
+                                },
+                                {
+                                    "name": "credits",
+                                    "pictureUrl": "https://eu-wotp.wgcdn.co/dcont/fb/image/new_credits_icon_440x440_png.png",
+                                    "dropRate": 0.01,
+                                    "amount": 250000
+                                },
+                                {
+                                    "name": "personal reserve: +50% credits",
+                                    "pictureUrl": "https://tanki-media-content.tanki.su/tanki-media/images/stronghold/awards/6.png",
+                                    "dropRate": 0.325,
+                                    "amount": 1
+                                },
+                                {
+                                    "name": "personal reserve: +50% credits",
+                                    "pictureUrl": "https://tanki-media-content.tanki.su/tanki-media/images/stronghold/awards/6.png",
+                                    "dropRate": 0.01,
+                                    "amount": 3
+                                },
+                                {
+                                    "name": "crew book: training booklet (random country)",
+                                    "pictureUrl": "https://content-wg.gcdn.co/locdoc/lootboxes_ep3/patrick-25/img/training-booklet.4feab5.png",
+                                    "dropRate": 0.15,
+                                    "amount": 1
+                                },
+                                {
+                                    "name": "crew book: universal manual",
+                                    "pictureUrl": "https://content-wg.gcdn.co/locdoc/book-cards/img/universalBook1.png",
+                                    "dropRate": 0.005,
+                                    "amount": 1
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "alias": "Filler slot 1 (Free XP)",
+                    "dropRate": 0.15,
+                    "contentType": "filler",
+                    "lootGroups": [
+                        {
+                            "alias": "Free XP",
+                            "dropRate": 1,
+                            "lootDrops": [
+                                {
+                                    "name": "free xp",
+                                    "pictureUrl": "https://na-wotp.wgcdn.co/dcont/fb/image/wot_xpicon_freexp_164x157.png",
+                                    "dropRate": 0.74,
+                                    "amount": 5000
+                                },
+                                {
+                                    "name": "free xp",
+                                    "pictureUrl": "https://na-wotp.wgcdn.co/dcont/fb/image/wot_xpicon_freexp_164x157.png",
+                                    "dropRate": 0.20,
+                                    "amount": 15000
+                                },
+                                {
+                                    "name": "free xp",
+                                    "pictureUrl": "https://na-wotp.wgcdn.co/dcont/fb/image/wot_xpicon_freexp_164x157.png",
+                                    "dropRate": 0.03,
+                                    "amount": 35000
+                                },
+                                {
+                                    "name": "free xp",
+                                    "pictureUrl": "https://na-wotp.wgcdn.co/dcont/fb/image/wot_xpicon_freexp_164x157.png",
+                                    "dropRate": 0.025,
+                                    "amount": 75000
+                                },
+                                {
+                                    "name": "free xp",
+                                    "pictureUrl": "https://na-wotp.wgcdn.co/dcont/fb/image/wot_xpicon_freexp_164x157.png",
+                                    "dropRate": 0.005,
+                                    "amount": 250000
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "alias": "Filler slot 2 (3D attachments)",
+                    "dropRate": 0.10,
+                    "contentType": "filler",
+                    "lootGroups": [
+                        {
+                            "alias": "3D attachments",
+                            "dropRate": 1,
+                            "lootDrops": [
+                                {
+                                    "name": "3D attachment",
+                                    "pictureUrl": "https://clan.akamai.steamstatic.com/images//39263509/fc34c8de5cfc7f4a2b4ef270dce8ad8f8a2011e2.png",
+                                    "dropRate": 1,
+                                    "amount": 1
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "alias": "Tanks",
+                    "dropRate": 0.02,
+                    "contentType": "main",
+                    "lootGroups": [
+                        {
+                            "alias": "Tanks",
+                            "dropRate": 1,
+                            "lootDrops": [
+                                {
+                                    "name": "Prototipo 6",
+                                    "displayPriority": 8,
+                                    "pictureUrl": "https://assets.tanks.gg/icons/tanks/standard/italy-It33_Prototipo_6.png",
+                                    "dropRate": 0.06,
+                                    "amount": 1,
+                                    "substitute": {
+                                        "name": "gold",
+                                        "pictureUrl": "https://discoff.net/image/cache/catalog/2500_gold-600x600.png",
+                                        "amount": 9400
+                                    }
+                                },
+                                {
+                                    "name": "Object 168 German",
+                                    "displayPriority": 8,
+                                    "pictureUrl": "https://assets.tanks.gg/icons/tanks/standard/ussr-R203_Object_168N.png",
+                                    "dropRate": 0.07,
+                                    "amount": 1,
+                                    "substitute": {
+                                        "name": "gold",
+                                        "pictureUrl": "https://discoff.net/image/cache/catalog/2500_gold-600x600.png",
+                                        "amount": 9100
+                                    }
+                                },
+                                {
+                                    "name": "Lätt Stridsfordon 120",
+                                    "displayPriority": 9,
+                                    "pictureUrl": "https://assets.tanks.gg/icons/tanks/standard/sweden-S33_Latt_Stridsfordon_120.png",
+                                    "dropRate": 0.07,
+                                    "amount": 1,
+                                    "substitute": {
+                                        "name": "gold",
+                                        "pictureUrl": "https://discoff.net/image/cache/catalog/2500_gold-600x600.png",
+                                        "amount": 11950
+                                    }
+                                },
+                                {
+                                    "name": "Char Mle. 75",
+                                    "displayPriority": 9,
+                                    "pictureUrl": "https://assets.tanks.gg/icons/tanks/standard/france-F118_Char_Mle_75.png",
+                                    "dropRate": 0.16,
+                                    "amount": 1,
+                                    "substitute": {
+                                        "name": "gold",
+                                        "pictureUrl": "https://discoff.net/image/cache/catalog/2500_gold-600x600.png",
+                                        "amount": 9500
+                                    }
+                                },
+                                {
+                                    "name": "K-2",
+                                    "displayPriority": 8,
+                                    "pictureUrl": "https://assets.tanks.gg/icons/tanks/standard/ussr-R192_K_2.png",
+                                    "dropRate": 0.16,
+                                    "amount": 1,
+                                    "substitute": {
+                                        "name": "gold",
+                                        "pictureUrl": "https://discoff.net/image/cache/catalog/2500_gold-600x600.png",
+                                        "amount": 10500
+                                    }
+                                },
+                                {
+                                    "name": "Turtle Mk. I",
+                                    "displayPriority": 8,
+                                    "pictureUrl": "https://assets.tanks.gg/icons/tanks/standard/uk-GB99_Turtle_Mk1.png",
+                                    "dropRate": 0.16,
+                                    "amount": 1,
+                                    "substitute": {
+                                        "name": "gold",
+                                        "pictureUrl": "https://discoff.net/image/cache/catalog/2500_gold-600x600.png",
+                                        "amount": 8700
+                                    }
+                                },
+                                {
+                                    "name": "T 54D",
+                                    "displayPriority": 9,
+                                    "pictureUrl": "https://assets.tanks.gg/icons/tanks/standard/germany-G169_T_54D.png",
+                                    "dropRate": 0.16,
+                                    "amount": 1,
+                                    "substitute": {
+                                        "name": "gold",
+                                        "pictureUrl": "https://discoff.net/image/cache/catalog/2500_gold-600x600.png",
+                                        "amount": 11000
+                                    }
+                                },
+                                {
+                                    "name": "Object 752",
+                                    "displayPriority": 9,
+                                    "pictureUrl": "https://assets.tanks.gg/icons/tanks/standard/ussr-R172_Object_752.png",
+                                    "dropRate": 0.16,
+                                    "amount": 1,
+                                    "substitute": {
+                                        "name": "gold",
+                                        "pictureUrl": "https://discoff.net/image/cache/catalog/2500_gold-600x600.png",
+                                        "amount": 13000
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/assets/lootTables/world_of_tanks_pc-2025_05-operation_pandora.json
+++ b/src/assets/lootTables/world_of_tanks_pc-2025_05-operation_pandora.json
@@ -7,14 +7,14 @@
     "autoOpenRecursive": false,
     "author": "DaSpood",
     "source": "'https://worldoftanks.asia/ko/news/specials/raumfalte-last-stand-2025-bundles/', bottom of the page, hidden by default",
-    "notes": "Not officially confirmed if duplicates are remove_even or remove_prop, assume the latter. 3D attachments bundled into 1 drop type because nobody cares about them.",
+    "notes": "3D attachments bundled into 1 drop type because nobody cares about them.",
     "lootboxes": [
         {
             "name": "Raumfalte Proto",
             "pictureUrl": "https://eu-wotp.wgcdn.co/dcont/fb/image/raumfalte_proto_small.png",
             "purchasable": true,
             "mainPrizeHardPity": 50,
-            "mainPrizeDuplicates": "remove_prop",
+            "mainPrizeDuplicates": "remove",
             "secondaryPrizeDuplicates": "allowed",
             "mainPrizeSubstitute": {
                 "name": "Raumfalte Prime",
@@ -265,7 +265,7 @@
             "pictureUrl": "https://eu-wotp.wgcdn.co/dcont/fb/image/raumfalte_alpha_small.png",
             "purchasable": false,
             "mainPrizeHardPity": 40,
-            "mainPrizeDuplicates": "remove_prop",
+            "mainPrizeDuplicates": "remove",
             "secondaryPrizeDuplicates": "allowed",
             "mainPrizeSubstitute": {
                 "name": "Raumfalte Prime",
@@ -548,7 +548,7 @@
             "pictureUrl": "https://eu-wotp.wgcdn.co/dcont/fb/image/raumfalte_prime_small.png",
             "purchasable": false,
             "mainPrizeHardPity": 20,
-            "mainPrizeDuplicates": "remove_prop",
+            "mainPrizeDuplicates": "remove",
             "secondaryPrizeDuplicates": "allowed",
             "mainPrizeSubstitute": {
                 "name": "Raumfalte Prime",

--- a/src/components/ButtonsFooter/ButtonsFooter.tsx
+++ b/src/components/ButtonsFooter/ButtonsFooter.tsx
@@ -81,7 +81,7 @@ export default function ButtonsFooter({
                                 currentlySimulating ||
                                 (!currentlyAutoOpening &&
                                     session.lootboxPendingCounters[selectedLootboxName] === 0 &&
-                                    session.simulatorConfig.openingMode !== 'unlimited')
+                                    session.simulatorConfig.openingMode === 'budget')
                             }
                         >
                             {getOpenButtonLabel()}

--- a/src/components/ButtonsFooter/ButtonsFooter.tsx
+++ b/src/components/ButtonsFooter/ButtonsFooter.tsx
@@ -63,13 +63,13 @@ export default function ButtonsFooter({
                         variant="outline-primary"
                         type="button"
                         onClick={onOpenPurchaseModal}
-                        className="w-100"
+                        className="icon-button"
                         disabled={currentlyAutoOpening || currentlyOpeningAll}
                     >
                         <BsCartPlus />
                     </Button>
                 </Col>
-                <Col className="col-4">
+                <Col className="col-4 d-inline-flex">
                     <Dropdown as={ButtonGroup} className="w-100">
                         <Button
                             variant="primary"
@@ -107,7 +107,12 @@ export default function ButtonsFooter({
                     </Dropdown>
                 </Col>
                 <Col className="col-auto">
-                    <Button variant="outline-primary" type="button" onClick={onOpenSettingsModal} className="w-100">
+                    <Button
+                        variant="outline-primary"
+                        type="button"
+                        onClick={onOpenSettingsModal}
+                        className="icon-button"
+                    >
                         <BsGear />
                     </Button>
                 </Col>

--- a/src/components/InfoHeader/InfoHeader.tsx
+++ b/src/components/InfoHeader/InfoHeader.tsx
@@ -1,5 +1,5 @@
 import { Button, Col, Container, Row } from 'react-bootstrap';
-import { BsGithub, BsJournalText } from 'react-icons/bs';
+import { BsBarChartLine, BsGithub } from 'react-icons/bs';
 import type { OpeningSession } from '../../types/state';
 
 export default function InfoHeader({
@@ -13,21 +13,26 @@ export default function InfoHeader({
         <Container fluid className="px-0 py-2">
             <Row className="d-flex gap-0 justify-content-between px-0 mx-0">
                 <Col className="col-auto">
-                    <Button variant="outline-primary" type="button" onClick={onOpenStatsPanel} className="w-100">
-                        <BsJournalText />
+                    <Button variant="outline-primary" type="button" onClick={onOpenStatsPanel} className="icon-button">
+                        <BsBarChartLine />
                     </Button>
                 </Col>
                 <Col className="flex-grow-1 text-center">
-                    <h2>
+                    <h2 className="d-none d-md-inline-block">
                         {session.referenceLootTable.game} - {session.referenceLootTable.eventName}
                     </h2>
+                    <h3 className="d-md-none d-inline-block">
+                        {session.referenceLootTable.game}
+                        <br />
+                        {session.referenceLootTable.eventName}
+                    </h3>
                 </Col>
                 <Col className="col-auto">
                     <Button
                         variant="outline-primary"
                         type="button"
                         onClick={() => window.open('https://github.com/DaSpood/Pandora')}
-                        className="w-100"
+                        className="icon-button"
                     >
                         <BsGithub />
                     </Button>

--- a/src/components/LootTableLoader/LootTableLoader.tsx
+++ b/src/components/LootTableLoader/LootTableLoader.tsx
@@ -25,7 +25,13 @@ export default function LootTableLoader({ onTableLoaded }: { onTableLoaded: (sub
                     import: 'default',
                     eager: true,
                 }),
-            ),
+            ).toSorted(
+                (a: unknown, b: unknown) =>
+                    // Z > A (WoT first)
+                    (b as LootTable).game.localeCompare((a as LootTable).game) ||
+                    // Most recent first
+                    (b as LootTable).startDate.localeCompare((a as LootTable).startDate),
+            ) as LootTable[],
         [],
     );
 

--- a/src/components/LootboxSelector/LootboxSelector.tsx
+++ b/src/components/LootboxSelector/LootboxSelector.tsx
@@ -33,30 +33,29 @@ export default function LootboxSelector({
                     )}
                 </Container>
                 <Row className="d-flex justify-content-center">
-                    {Object.keys(session.lootboxPendingCounters).map((lootboxName, idx) => (
-                        <Col key={idx} className="col-3 col-lg-2 col-xxl-1">
-                            <Container
-                                className={`h-100 d-flex flex-column justify-content-between p-2 ${selectedLootboxName === lootboxName ? 'bg-gradient' : ''} rounded text-center`}
-                                style={{ cursor: locked ? 'default' : 'pointer' }}
-                                onClick={() => (locked ? () => {} : onSelectedLootboxNameChanged(lootboxName))}
-                            >
-                                <Image
-                                    src={
-                                        session.referenceLootTable.lootboxes.find(
-                                            (box: Lootbox) => box.name === lootboxName,
-                                        )!.pictureUrl || 'default-loot-box.png'
-                                    }
-                                    alt={lootboxName}
-                                    className="object-fit-contain flex-grow-1"
-                                />
-                                {!session.referenceLootTable.lootboxes.find((box: Lootbox) => box.name === lootboxName)!
-                                    .pictureUrl && <p>{lootboxName}</p>}
-                                {session.simulatorConfig.openingMode === 'budget' && (
-                                    <p>x{session.lootboxPendingCounters[lootboxName]}</p>
-                                )}
-                            </Container>
-                        </Col>
-                    ))}
+                    {session.referenceLootTable.lootboxes
+                        .filter((box: Lootbox) =>
+                            session.referenceLootTable.autoOpenRecursive ? box.purchasable : true,
+                        )
+                        .map((box: Lootbox, idx: number) => (
+                            <Col key={idx} className="col-3 col-lg-2 col-xxl-1">
+                                <Container
+                                    className={`h-100 d-flex flex-column justify-content-between p-2 ${selectedLootboxName === box.name ? 'bg-gradient' : ''} rounded text-center`}
+                                    style={{ cursor: locked ? 'default' : 'pointer' }}
+                                    onClick={() => (locked ? () => {} : onSelectedLootboxNameChanged(box.name))}
+                                >
+                                    <Image
+                                        src={box.pictureUrl || 'default-loot-box.png'}
+                                        alt={box.name}
+                                        className="object-fit-contain flex-grow-1"
+                                    />
+                                    {!box.pictureUrl && <p>{box.name}</p>}
+                                    {session.simulatorConfig.openingMode === 'budget' && (
+                                        <p>x{session.lootboxPendingCounters[box.name]}</p>
+                                    )}
+                                </Container>
+                            </Col>
+                        ))}
                 </Row>
             </Container>
         )

--- a/src/components/PurchaseModal/PurchaseModal.tsx
+++ b/src/components/PurchaseModal/PurchaseModal.tsx
@@ -62,12 +62,14 @@ export default function PurchaseModal({
             </ModalHeader>
             <ModalBody>
                 <Container className="d-flex flex-column gap-4 p-0 overflow-y-auto">
-                    <FormCheck
-                        type="switch"
-                        label="Show non-purchasable lootboxes"
-                        checked={displayNonPurchasable}
-                        onChange={(e) => setDisplayNonPurchasable(e.target.checked)}
-                    />
+                    {!session.referenceLootTable.autoOpenRecursive && (
+                        <FormCheck
+                            type="switch"
+                            label="Show non-purchasable lootboxes"
+                            checked={displayNonPurchasable}
+                            onChange={(e) => setDisplayNonPurchasable(e.target.checked)}
+                        />
+                    )}
                     <ListGroup>
                         {session.referenceLootTable.lootboxes
                             .filter((lootbox: Lootbox) => (displayNonPurchasable ? true : lootbox.purchasable))

--- a/src/components/ResultDisplay/ResultDisplay.tsx
+++ b/src/components/ResultDisplay/ResultDisplay.tsx
@@ -1,11 +1,121 @@
 import { Col, Container, Image, Row } from 'react-bootstrap';
 import type { OpeningSession } from '../../types/state';
+import type { Maybe } from '../../types/utils';
+import Chart from 'react-apexcharts';
+import type { ApexOptions } from 'apexcharts';
 
-export default function ResultDisplay({ session }: { session: OpeningSession }) {
+export default function ResultDisplay({
+    session,
+    simulationResult,
+}: {
+    session: OpeningSession;
+    simulationResult: Maybe<number[]>;
+}) {
+    const renderSimulationResultGraph = () => {
+        if (!simulationResult?.length) return;
+
+        const uniquePoints = Array.from(new Set(simulationResult));
+        const firstQuartile = uniquePoints.sort((a, b) => a - b)[Math.round(uniquePoints.length / 4)];
+        const median = uniquePoints.sort((a, b) => a - b)[Math.round(uniquePoints.length / 2)];
+        const thirdQuartile = uniquePoints.sort((a, b) => a - b)[Math.round(uniquePoints.length / 4) * 3];
+        const min = Math.min(...uniquePoints);
+        const avg = Math.round(uniquePoints.reduce((acc, val) => acc + val, 0) / uniquePoints.length);
+        const max = Math.max(...uniquePoints);
+
+        const series = [
+            {
+                name: 'Boxes required to reach goal',
+                data: uniquePoints.map((x) => ({
+                    x: x,
+                    y: simulationResult.filter((val) => val === x).length,
+                })),
+            },
+        ];
+
+        const options = {
+            title: {
+                text: `${new Intl.NumberFormat('en-US').format(simulationResult.length).replaceAll(',', ' ')} simulations`,
+            },
+            tooltip: {
+                enabled: false,
+            },
+            chart: {
+                id: 'simulation-chart',
+                background: 'white',
+                toolbar: {
+                    show: false,
+                },
+            },
+            xaxis: {
+                type: 'numeric',
+                title: {
+                    text: 'Number of boxes purchased',
+                },
+            },
+            yaxis: {
+                title: {
+                    text: 'Frequency',
+                },
+            },
+            dataLabels: {
+                enabled: false,
+            },
+            stroke: {
+                curve: 'smooth',
+            },
+        } as unknown as ApexOptions;
+
+        return (
+            <Container className="d-flex flex-column justify-content-center">
+                {simulationResult.length >= 8000 && (
+                    <>
+                        <Container className="w-auto m-auto d-md-none d-inline-block">
+                            <h4>Results after {simulationResult.length} iterations</h4>
+                            <p className="text-muted">
+                                <i>Screen too small to display a graph)</i>
+                            </p>
+                            <br />
+                        </Container>
+                        <Container className="d-none d-md-inline-block">
+                            <Chart options={options} series={series} type="area" height="450px" />
+                        </Container>
+                    </>
+                )}
+                {simulationResult.length < 8000 && (
+                    <Container className="w-auto m-auto">
+                        <h4>Results after {simulationResult.length} iterations</h4>
+                        <p className="text-muted">
+                            <i>Launch 8000 simulations or more to generate a graph (disabled on small devices)</i>
+                        </p>
+                        <br />
+                    </Container>
+                )}
+                <Row className="w-100 p-0 justify-content-center">
+                    <Col className="col-auto p-0">
+                        <ul>
+                            <li>Minimum: {min}</li>
+                            <li>Average: {avg}</li>
+                            <li>Maximum: {max}</li>
+                        </ul>
+                    </Col>
+                    <Col className="col-auto p-0">
+                        <ul>
+                            <li>1st Quartile: {firstQuartile}</li>
+                            <li>Median: {median}</li>
+                            <li>3rd Quartile: {thirdQuartile}</li>
+                        </ul>
+                    </Col>
+                </Row>
+            </Container>
+        );
+    };
+
     return (
         <Container fluid>
             <Row className="d-flex justify-content-center">
+                {simulationResult && renderSimulationResultGraph()}
                 {session.history.length > 0 &&
+                    !simulationResult &&
                     session.history[session.history.length - 1].drops.map((drop, idx) => (
                         <Col key={idx} className="col-4 col-lg-2">
                             <Container
@@ -22,7 +132,7 @@ export default function ResultDisplay({ session }: { session: OpeningSession }) 
                             </Container>
                         </Col>
                     ))}
-                {session.history.length == 0 && (
+                {session.history.length == 0 && !simulationResult && (
                     <p className="d-block d-lg-none text-center">
                         This app is not intended to be used on a mobile device. If the "open" button is hidden, you can
                         zoom-in, scroll down and zoom-out to collapse the browser's search bar and display the whole

--- a/src/components/ResultDisplay/ResultDisplay.tsx
+++ b/src/components/ResultDisplay/ResultDisplay.tsx
@@ -122,12 +122,15 @@ export default function ResultDisplay({
                                 className={`h-100 d-flex flex-column justify-content-between p-2 bg-gradient rounded text-center ${drop.rarityInUi === 'main' ? 'border border-warning' : ''} ${drop.rarityInUi === 'secondary' ? 'border border-info' : ''}`}
                             >
                                 <Image
-                                    src={session.lootTableUniqueDrops[drop.name]?.pictureUrl || 'default-loot-icon.png'}
-                                    alt={drop.name}
+                                    src={
+                                        session.referenceLootTableUniqueDrops[drop.lootTableBranch.drop.name]?.drop
+                                            .pictureUrl || 'default-loot-icon.png'
+                                    }
+                                    alt={drop.lootTableBranch.drop.name}
                                     className="object-fit-contain flex-grow-1"
                                 />
                                 <p>
-                                    {drop.amount}x {drop.name}
+                                    {drop.amount}x {drop.lootTableBranch.drop.name}
                                 </p>
                             </Container>
                         </Col>

--- a/src/components/SettingsModal/SettingsModal.tsx
+++ b/src/components/SettingsModal/SettingsModal.tsx
@@ -84,9 +84,9 @@ export default function SettingsModal({
             setThreads(Math.abs(loadedConfig.simulatorThreads ?? 0) || 1);
             setIterationsPerThread(Math.abs(loadedConfig.simulatorIterationsPerThread ?? 0) || 1);
 
-            const acceptedDropNames: string[] = Object.values(session.lootTableUniqueDrops)
+            const acceptedDropNames: string[] = Object.values(session.referenceLootTableUniqueDrops)
                 .filter((drop) => drop.type !== 'filler')
-                .map((drop) => drop.name);
+                .map((drop) => drop.drop.name);
             const loadedPreOwnedPrizes = loadedConfig.preOwnedPrizes.reduce(
                 (acc, prize) => {
                     acc[prize.name] = { name: prize.name, type: prize.type };
@@ -176,27 +176,27 @@ export default function SettingsModal({
         }
     };
 
-    const mainDropsSubjectToDuplicationRules = Object.values(session.lootTableUniqueDrops)
+    const mainDropsSubjectToDuplicationRules = Object.values(session.referenceLootTableUniqueDrops)
         .filter((drop) => drop.type === 'main')
         .filter((drop) => !drop.isSubstitute)
         .filter((drop) => drop.isSubjectToDuplicationRules)
-        .toSorted((a, b) => b.priority - a.priority || a.name.localeCompare(b.name));
+        .toSorted((a, b) => b.priority - a.priority || a.drop.name.localeCompare(b.drop.name));
 
-    const secondaryDropsSubjectToDuplicationRules = Object.values(session.lootTableUniqueDrops)
+    const secondaryDropsSubjectToDuplicationRules = Object.values(session.referenceLootTableUniqueDrops)
         .filter((drop) => drop.type === 'secondary')
         .filter((drop) => !drop.isSubstitute)
         .filter((drop) => drop.isSubjectToDuplicationRules)
-        .toSorted((a, b) => b.priority - a.priority || a.name.localeCompare(b.name));
+        .toSorted((a, b) => b.priority - a.priority || a.drop.name.localeCompare(b.drop.name));
 
-    const targettableMainDrops = Object.values(session.lootTableUniqueDrops)
+    const targettableMainDrops = Object.values(session.referenceLootTableUniqueDrops)
         .filter((drop) => drop.type === 'main')
         .filter((drop) => !drop.isSubstitute)
-        .toSorted((a, b) => b.priority - a.priority || a.name.localeCompare(b.name));
+        .toSorted((a, b) => b.priority - a.priority || a.drop.name.localeCompare(b.drop.name));
 
-    const targettableSecondaryDrops = Object.values(session.lootTableUniqueDrops)
+    const targettableSecondaryDrops = Object.values(session.referenceLootTableUniqueDrops)
         .filter((drop) => drop.type === 'secondary')
         .filter((drop) => !drop.isSubstitute)
-        .toSorted((a, b) => b.priority - a.priority || a.name.localeCompare(b.name));
+        .toSorted((a, b) => b.priority - a.priority || a.drop.name.localeCompare(b.drop.name));
 
     const renderBody = () => {
         return (
@@ -321,10 +321,14 @@ export default function SettingsModal({
                                                 <Col key={`targetMain_${idx}`} className="col-6 col-lg-3">
                                                     <FormCheck
                                                         type="checkbox"
-                                                        label={drop.name}
-                                                        checked={Object.keys(targetPrizes).includes(drop.name)}
+                                                        label={drop.drop.name}
+                                                        checked={Object.keys(targetPrizes).includes(drop.drop.name)}
                                                         onChange={(e) =>
-                                                            onCheckChangeTarget(drop.name, drop.type, e.target.checked)
+                                                            onCheckChangeTarget(
+                                                                drop.drop.name,
+                                                                drop.type,
+                                                                e.target.checked,
+                                                            )
                                                         }
                                                     />
                                                 </Col>
@@ -347,10 +351,14 @@ export default function SettingsModal({
                                                 <Col key={`targetSec_${idx}`} className="col-6 col-lg-3">
                                                     <FormCheck
                                                         type="checkbox"
-                                                        label={drop.name}
-                                                        checked={Object.keys(targetPrizes).includes(drop.name)}
+                                                        label={drop.drop.name}
+                                                        checked={Object.keys(targetPrizes).includes(drop.drop.name)}
                                                         onChange={(e) =>
-                                                            onCheckChangeTarget(drop.name, drop.type, e.target.checked)
+                                                            onCheckChangeTarget(
+                                                                drop.drop.name,
+                                                                drop.type,
+                                                                e.target.checked,
+                                                            )
                                                         }
                                                     />
                                                 </Col>
@@ -373,11 +381,11 @@ export default function SettingsModal({
                                                 <Col key={`preOwnedMain_${idx}`} className="col-6 col-lg-3">
                                                     <FormCheck
                                                         type="checkbox"
-                                                        label={drop.name}
-                                                        checked={Object.keys(preOwnedPrizes).includes(drop.name)}
+                                                        label={drop.drop.name}
+                                                        checked={Object.keys(preOwnedPrizes).includes(drop.drop.name)}
                                                         onChange={(e) =>
                                                             onCheckChangePreOwned(
-                                                                drop.name,
+                                                                drop.drop.name,
                                                                 drop.type,
                                                                 e.target.checked,
                                                             )
@@ -403,11 +411,11 @@ export default function SettingsModal({
                                                 <Col key={`preOwnedSec_${idx}`} className="col-6 col-lg-3">
                                                     <FormCheck
                                                         type="checkbox"
-                                                        label={drop.name}
-                                                        checked={Object.keys(preOwnedPrizes).includes(drop.name)}
+                                                        label={drop.drop.name}
+                                                        checked={Object.keys(preOwnedPrizes).includes(drop.drop.name)}
                                                         onChange={(e) =>
                                                             onCheckChangePreOwned(
-                                                                drop.name,
+                                                                drop.drop.name,
                                                                 drop.type,
                                                                 e.target.checked,
                                                             )

--- a/src/components/SettingsModal/SettingsModal.tsx
+++ b/src/components/SettingsModal/SettingsModal.tsx
@@ -267,10 +267,10 @@ export default function SettingsModal({
                                     <AccordionBody className="d-flex flex-column gap-2">
                                         <InputGroup className="d-flex flex-row justify-content-start text-start">
                                             <Col className="col-auto col-md-3 d-flex flex-column justify-content-center">
-                                                <FormLabel>Parallel instances:</FormLabel>
+                                                <FormLabel>Instances:</FormLabel>
                                             </Col>
                                             <Col className="col-1 d-md-none flex-grow-1 flex-md-grow-0" />
-                                            <Col className="col-2 col-md-1 d-flex flex-column justify-content-center">
+                                            <Col className="col-4 col-md-2 d-flex flex-column justify-content-center">
                                                 <FormControl
                                                     type="number"
                                                     value={threads}
@@ -282,10 +282,10 @@ export default function SettingsModal({
                                         </InputGroup>
                                         <InputGroup className="d-flex flex-row justify-content-start text-start">
                                             <Col className="col-auto col-md-3 d-flex flex-column justify-content-center gap-2">
-                                                <FormLabel>Simulations per instance:</FormLabel>
+                                                <FormLabel>Iterations:</FormLabel>
                                             </Col>
                                             <Col className="col-1 d-md-none flex-grow-1 flex-md-grow-0" />
-                                            <Col className="col-2 col-md-1 d-flex flex-column justify-content-center">
+                                            <Col className="col-4 col-md-2 d-flex flex-column justify-content-center">
                                                 <FormControl
                                                     type="number"
                                                     value={iterationsPerThread}
@@ -297,8 +297,11 @@ export default function SettingsModal({
                                         </InputGroup>
                                         <p className="text-muted">
                                             <i>
-                                                Number of parallel instances should not exceed your CPU's core count for
-                                                ideal performances.
+                                                The app will run "instances" simulators in parallel, each running
+                                                "iterations" attempts to obtain your goal. The more total attempts you
+                                                run, the more accurate the stats will be (it is recommended to run at
+                                                least 8000). If only 1 attempt is run, the result will be saved in the
+                                                stats panel.
                                             </i>
                                         </p>
                                     </AccordionBody>

--- a/src/components/StatsLeftPanel/StatsLeftPanel.tsx
+++ b/src/components/StatsLeftPanel/StatsLeftPanel.tsx
@@ -108,8 +108,8 @@ export default function StatsLeftPanel({
                         {Object.keys(session.aggregatedResults)
                             .sort(
                                 (a, b) =>
-                                    session.lootTableUniqueDrops[b].priority -
-                                        session.lootTableUniqueDrops[a].priority || a.localeCompare(b),
+                                    session.referenceLootTableUniqueDrops[b].priority -
+                                        session.referenceLootTableUniqueDrops[a].priority || a.localeCompare(b),
                             )
                             .filter((rewardName) =>
                                 displayUnobtainedRewards ? true : session.aggregatedResults[rewardName] > 0,
@@ -122,7 +122,7 @@ export default function StatsLeftPanel({
                                     <Col className="col-2">
                                         <Image
                                             src={
-                                                session.lootTableUniqueDrops[rewardName].pictureUrl ||
+                                                session.referenceLootTableUniqueDrops[rewardName].drop.pictureUrl ||
                                                 'default-loot-drop.png'
                                             }
                                             alt={rewardName}
@@ -208,7 +208,7 @@ export default function StatsLeftPanel({
                                                     {new Intl.NumberFormat('en-US')
                                                         .format(drop.amount)
                                                         .replaceAll(',', ' ')}
-                                                    x {drop.name}
+                                                    x {drop.lootTableBranch.drop.name}
                                                 </span>
                                             </li>
                                         ))}

--- a/src/components/StatsLeftPanel/StatsLeftPanel.tsx
+++ b/src/components/StatsLeftPanel/StatsLeftPanel.tsx
@@ -38,7 +38,7 @@ export default function StatsLeftPanel({
         const href = URL.createObjectURL(blob);
         const link = document.createElement('a');
         link.href = href;
-        link.download = 'session.json';
+        link.download = 'pandora_session.json';
         document.body.appendChild(link);
         link.click();
         document.body.removeChild(link);

--- a/src/scripts/openingSessionManager.ts
+++ b/src/scripts/openingSessionManager.ts
@@ -152,6 +152,8 @@ export const newSession = (rawTable: string, checksum: string): OpeningSession =
             openingMode: 'unlimited',
             preOwnedPrizes: [],
             targetPrizes: [],
+            simulatorThreads: 1,
+            simulatorIterationsPerThread: 1,
         },
     };
 };

--- a/src/scripts/openingWorker.ts
+++ b/src/scripts/openingWorker.ts
@@ -1,0 +1,16 @@
+import { openUntilMultipleIterations } from './openingSessionManager.ts';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const self = globalThis as any;
+
+self.onmessage = (event: MessageEvent) => {
+    const { rawInitialSession, iterations, workerId } = event.data;
+
+    // Avoid duplicate calls
+    if (Object.keys(self).includes(`worker_${workerId}_working`)) return;
+
+    self[`worker_${workerId}_working`] = true;
+    const result = openUntilMultipleIterations(rawInitialSession, iterations);
+    postMessage({ workerId, result });
+    delete self[`worker_${workerId}_working`];
+};

--- a/src/tests/invalid.json
+++ b/src/tests/invalid.json
@@ -14,7 +14,7 @@
             "pictureUrl": "https://eu-wotp.wgcdn.co/dcont/fb/image/raumfalte_proto_small.png",
             "purchasable": false,
             "pity": 0,
-            "mainPrizeDuplicates": "remove_prop",
+            "mainPrizeDuplicates": "remove",
             "mainPrizeSubstitute": {
                 "name": "Raumfalte Prime",
                 "pictureUrl": "https://eu-wotp.wgcdn.co/dcont/fb/image/raumfalte_prime_small.png",
@@ -257,8 +257,8 @@
             "pictureUrl": "https://eu-wotp.wgcdn.co/dcont/fb/image/raumfalte_alpha_small.png",
             "purchasable": false,
             "pity": 40,
-            "mainPrizeDuplicates": "remove_prop",
-            "secondaryPrizeDuplicates": "remove_prop",
+            "mainPrizeDuplicates": "remove",
+            "secondaryPrizeDuplicates": "remove",
             "lootSlots": [
                 {
                     "alias": "Guaranteed slot 1 (Free XP)",

--- a/src/types/lootTable.d.ts
+++ b/src/types/lootTable.d.ts
@@ -36,17 +36,21 @@ export interface LootTable {
      */
     recursive: boolean;
     /**
-     * Whether recursively-dropped lootboxes are auto-opened instantly. WARNING: NOT IMPLEMENTED YET.
+     * Whether recursively-dropped lootboxes are auto-opened instantly.
      *
      * Can only be true if `recursive` is also true.
      *
-     * If true, all non-purchasable lootboxes will be hidden from the UI (unless restrictions are bypassed) and
-     * auto-opened immediately when dropped (their resulting drops will be included as if they belong to the parent box)
+     * If true, all non-purchasable lootboxes will be hidden from the UI, and all boxes will be auto-opened immediately
+     * when dropped from another box (their resulting drops will be included as if they belong to the parent box, but
+     * drops of the same item won't be combined into one).
      *
      * This can be used to hide logically-tiered lootboxes that only exist to represent deeper systems. For example,
      * Genshin Impact's 50/50 mechanic means the default lootbox's "5 star" (main prize) drop is a recursive lootbox, in
      * which two slots exist: secondary (permanent banner) rewards and main (event banner) rewards, with a hard pity of
      * 1.
+     *
+     * Note: This feature was not tested very thoroughly. It should work, but there may be edge cases or state
+     *       corruptions that I didn't catch. Open an issue if you find a bug.
      */
     autoOpenRecursive: boolean;
     /**

--- a/src/types/lootTable.d.ts
+++ b/src/types/lootTable.d.ts
@@ -91,6 +91,11 @@ export interface Lootbox {
      *
      * By default, except in "unlimited" mode, the simulator will only let you open purchasable boxes, though you can
      * choose to bypass this restriction if wanted.
+     *
+     * In "until" mode, if multiple lootboxes are "purchasable", the simulator will use the first one it finds.
+     * Note: this could probably be configurable, but I don't think there is any known game where a *single* loot table
+     *       contains multiple purchasable boxes that aren't effectively the same with a minor difference that could be
+     *       abstracted anyway (WoT holiday ops boxes with filler materials, Genshin "banner character"...).
      */
     purchasable: boolean;
     /**

--- a/src/types/state.d.ts
+++ b/src/types/state.d.ts
@@ -133,6 +133,12 @@ export interface SessionConfiguration {
      * List of prizes which the simulator should obtain before stopping in 'unlimited' mode.
      */
     targetPrizes: { name: string; type: LootDropType }[];
-
-    // `slowOpening: boolean` for auto-opening modes to display each result in the UI with a slight delay or only display final results?
+    /**
+     * How many simulator workers will run in parallel. Not lower than 1.
+     */
+    simulatorThreads: number;
+    /**
+     * How many simulations will run in each worker. Not lower than 1.
+     */
+    simulatorIterationsPerThread: number;
 }


### PR DESCRIPTION
- Add `until` opening mode and associated settings
- Add JSON export / import of settings
    - Importing settings with a loot table checksum mismatch will cause a warning but won't block the import
    - Incompatible settings will simply be ignored. Re-exporting loaded settings will update them to "fit" the current
      loot table
- Add support for "logical" recursive boxes (auto-opening them immediately when dropped, and adding their content to the
  original box's result)
- Add loot table for WoT PC's Holiday Ops 2024 event
- Add loot table for WoT PC's Paint It GREEN! event
- Loot table format is now considered stable. If it needs to be modified, the modification should be new optional fields
  only, and breaking changes should be handled with backwards compatibility.